### PR TITLE
Add Task Use Case

### DIFF
--- a/src/main/java/use_cases/add_task/AddTaskController.java
+++ b/src/main/java/use_cases/add_task/AddTaskController.java
@@ -1,0 +1,39 @@
+package use_cases.add_task;
+
+/**
+ * Controller for the Add Task use case; receives user input from the UI.
+ *
+ * Created: 11/20/2022
+ * Last updated: 11/21/2022
+ *
+ * @author Bmguiler
+ */
+public class AddTaskController {
+    private AddTaskInputBoundary userInput;
+
+    /**
+     * Controller constructor.
+     *
+     * @param userInput the user input passed from the UI.
+     */
+    public AddTaskController(AddTaskInputBoundary userInput){
+        this.userInput = userInput;
+    }
+
+    /**
+     * Add Task method for the UI to call when the user clicks to add a task on
+     * the dashboard.
+     *
+     * @param taskName the name of the task to be added.
+     * @param taskDescription the description of the task to be added.
+     * @param parentId the id of the parent task of the task to be added.
+     * @param curriculumId the id of the curriculum that the task is going
+     *                     to be added to.
+     */
+    public void addTask(String taskName, String taskDescription, int parentId,
+                        int curriculumId){
+        this.userInput.addTask(taskName, taskDescription, parentId, curriculumId);
+    }
+
+    // TODO: what if there is no parent task?
+}

--- a/src/main/java/use_cases/add_task/AddTaskInputBoundary.java
+++ b/src/main/java/use_cases/add_task/AddTaskInputBoundary.java
@@ -1,0 +1,15 @@
+package use_cases.add_task;
+
+/**
+ * An input boundary interface that is implemented by the Add Task Use Case class.
+ *
+ * Created: 11/20/2022
+ * Last updated: 11/21/2022
+ *
+ * @author Bmguiler
+ */
+
+public interface AddTaskInputBoundary {
+    void addTask(String taskName, String taskDescription, int parentId,
+                 int curriculumId);
+}

--- a/src/main/java/use_cases/add_task/AddTaskModel.java
+++ b/src/main/java/use_cases/add_task/AddTaskModel.java
@@ -1,0 +1,68 @@
+package use_cases.add_task;
+
+/**
+ * A model class for packaging the required info needed by the AddTaskPresenter.
+ *
+ * Created: 11/20/2022
+ * Last updated: 11/21/2022
+ *
+ * @author Bmguiler
+ */
+
+public class AddTaskModel {
+    private final String taskName;
+    private final String taskDescription;
+    private final String curriculumName;
+    private final String parentTaskName;
+
+    /**
+     * Add Task Model Constructor method.
+     * @param taskName the name of the task being added.
+     * @param taskDescription the description of the task being added.
+     * @param curriculumName the name of the curriculum that the task is being added to.
+     * @param parentTaskName the name of the parent task of the task being added.
+     */
+    public AddTaskModel(String taskName, String taskDescription,
+                        String curriculumName, String parentTaskName){
+        this.taskName = taskName;
+        this.taskDescription = taskDescription;
+        this.curriculumName = curriculumName;
+        this.parentTaskName = parentTaskName;
+    }
+
+    /**
+     * Get the task's name.
+     *
+     * @return the task's name.
+     */
+    public String getTaskName(){
+        return this.taskName;
+    }
+
+    /**
+     * Get the task's description.
+     *
+     * @return the task's description.
+     */
+    public String getTaskDescription(){
+        return this.taskDescription;
+    }
+
+    /**
+     * Get the curriculum's name.
+     *
+     * @return the curriculum's name.
+     */
+    public String getCurriculumName(){
+        return this.curriculumName;
+    }
+
+    /**
+     * Get the parent task's name.
+     *
+     * @return the parent task's name.
+     */
+    public String getParentTaskName() { return this.parentTaskName;}
+
+
+}

--- a/src/main/java/use_cases/add_task/AddTaskOutputBoundary.java
+++ b/src/main/java/use_cases/add_task/AddTaskOutputBoundary.java
@@ -1,0 +1,14 @@
+package use_cases.add_task;
+
+/**
+ * An output boundary interface that is implemented by the addTaskPresenter class.
+ *
+ * Created: 11/20/2022
+ * Last updated: 11/21/2022
+ *
+ * @author Bmguiler
+ */
+
+public interface AddTaskOutputBoundary {
+    String taskAdded(AddTaskModel newTask);
+}

--- a/src/main/java/use_cases/add_task/AddTaskPresenter.java
+++ b/src/main/java/use_cases/add_task/AddTaskPresenter.java
@@ -1,0 +1,31 @@
+package use_cases.add_task;
+
+/**
+ * Presenter for the UI that confirms that the task was added to the correct
+ * curriculum and correct parent task.
+ *
+ * Created: 11/20/2022
+ * Last updated: 11/21/2022
+ *
+ * @author Bmguiler
+ */
+
+public class AddTaskPresenter implements AddTaskOutputBoundary {
+
+    /**
+     * Display a message that the task was added.
+     *
+     * @param newTask model containing the added task's information.
+     * @return a message confirming the task was added.
+     */
+    @Override
+    public String taskAdded(AddTaskModel newTask) {
+        return "New task with name: " + newTask.getTaskName() + " and description: "
+                + newTask.getTaskDescription()
+                + " was successfully added to the curriculum: "
+                + newTask.getCurriculumName()
+                + " as a subtask of: "
+                + newTask.getParentTaskName()
+                + ".";
+    }
+}

--- a/src/main/java/use_cases/add_task/AddTaskUseCase.java
+++ b/src/main/java/use_cases/add_task/AddTaskUseCase.java
@@ -1,0 +1,66 @@
+package use_cases.add_task;
+import entity_factories.TaskFactory;
+import entity_factories.TaskTreeFactory;
+import entity_layer.*;
+
+/**
+ * Use Case for adding a task.
+ *
+ * Created: 11/20/2022
+ * Last updated: 11/21/2022
+ *
+ * @author Bmguiler
+ */
+
+public class AddTaskUseCase implements AddTaskInputBoundary{
+
+    private final AddTaskOutputBoundary presenter;
+    private final TaskFactory taskFactory;
+    private final TaskTreeFactory taskTreeFactory;
+
+
+    /**
+     * Add Task Use Case constructor method.
+     *
+     * @param presenter the presenter class for thr UI.
+     * @param taskFactory creates a new Task object.
+     * @param taskTreeFactory creates a new Task Tree object.
+     */
+    public AddTaskUseCase(AddTaskOutputBoundary presenter,
+                          TaskFactory taskFactory, TaskTreeFactory taskTreeFactory){
+        this.presenter = presenter;
+        this.taskFactory = taskFactory;
+        this.taskTreeFactory = taskTreeFactory;
+    }
+
+    /**
+     * Given a name and description from the user, add a new task to the
+     * curriculum and parent task they chose to add a task to.
+     *
+     * @param taskName what the user has named the new task.
+     * @param taskDescription what the user has given as a description for
+     *                        the new task.
+     * @param parentId the unique id of the parent task of the new task.
+     * @param curriculumId the specific id unique to the curriculum that the
+     *                     new task will be in.
+     */
+    @Override
+    public void addTask(String taskName, String taskDescription, int parentId,
+                        int curriculumId) {
+
+        Task newTask = this.taskFactory.create(taskName, taskDescription);
+        TaskTree newTaskTree = this.taskTreeFactory.create();
+        // may need to implement a new line if we want to create a new task with a duration.
+
+        Schedule schedule = InMemoryUser.getActiveUser().getSchedule();
+        Curriculum curriculum = schedule.getCurriculum(curriculumId);
+        TaskTree parentTaskTree = curriculum.getTaskTreeByID(parentId);
+        parentTaskTree.addSubTaskTree(newTaskTree);
+
+        String curriculumName = curriculum.getName();
+        String parentTaskName = parentTaskTree.getTask().getName();
+        AddTaskModel addedTask = new AddTaskModel(taskName,
+                taskDescription, curriculumName, parentTaskName);
+        presenter.taskAdded(addedTask);
+    }
+}

--- a/src/main/java/use_cases/complete_task/CompleteTaskController.java
+++ b/src/main/java/use_cases/complete_task/CompleteTaskController.java
@@ -1,4 +1,4 @@
-package complete_task;
+package use_cases.complete_task;
 
 /**
  * Controller for the completeTask use case; receives user input
@@ -9,10 +9,10 @@ package complete_task;
  *
  * @author Bmguiler
  */
-public class completeTaskController {
-    private completeTaskInputBoundary userInput;
+public class CompleteTaskController {
+    private CompleteTaskInputBoundary userInput;
 
-    public completeTaskController(completeTaskInputBoundary userInput){
+    public CompleteTaskController(CompleteTaskInputBoundary userInput){
         this.userInput = userInput;
     }
 

--- a/src/main/java/use_cases/complete_task/CompleteTaskInputBoundary.java
+++ b/src/main/java/use_cases/complete_task/CompleteTaskInputBoundary.java
@@ -1,4 +1,4 @@
-package complete_task;
+package use_cases.complete_task;
 
 
 /**
@@ -9,6 +9,6 @@ package complete_task;
  *
  * @author Bmguiler
  */
-public interface completeTaskInputBoundary {
+public interface CompleteTaskInputBoundary {
     void completeTask(int curriculumId, int taskId);
 }

--- a/src/main/java/use_cases/complete_task/CompleteTaskOutputBoundary.java
+++ b/src/main/java/use_cases/complete_task/CompleteTaskOutputBoundary.java
@@ -1,4 +1,4 @@
-package complete_task;
+package use_cases.complete_task;
 
 /**
  * An output boundary interface that is implemented by the completeTaskPresenter class.
@@ -8,6 +8,6 @@ package complete_task;
  *
  * @author Bmguiler
  */
-public interface completeTaskOutputBoundary {
+public interface CompleteTaskOutputBoundary {
     String taskCompleted(CompletedTaskModel completedTask);
 }

--- a/src/main/java/use_cases/complete_task/CompleteTaskPresenter.java
+++ b/src/main/java/use_cases/complete_task/CompleteTaskPresenter.java
@@ -1,4 +1,4 @@
-package complete_task;
+package use_cases.complete_task;
 
 /**
  * Presenter for the UI that confirms that the task was completed.
@@ -8,10 +8,10 @@ package complete_task;
  *
  * @author Bmguiler
  */
-public class completeTaskPresenter implements completeTaskOutputBoundary{
+public class CompleteTaskPresenter implements CompleteTaskOutputBoundary {
 
     /**
-     * Confirm that the task was completed.
+     * Display a message that the task was completed.
      *
      * @param taskCompleted model containing completed task information.
      * @return a message confirming the task was completed.

--- a/src/main/java/use_cases/complete_task/CompleteTaskUseCase.java
+++ b/src/main/java/use_cases/complete_task/CompleteTaskUseCase.java
@@ -1,4 +1,4 @@
-package complete_task;
+package use_cases.complete_task;
 import entity_layer.*;
 
 /**
@@ -10,10 +10,10 @@ import entity_layer.*;
  * @author Bmguiler
  */
 
-public class completeTaskUseCase implements completeTaskInputBoundary {
-    private completeTaskOutputBoundary presenter;
+public class CompleteTaskUseCase implements CompleteTaskInputBoundary {
+    private CompleteTaskOutputBoundary presenter;
 
-    public completeTaskUseCase(completeTaskOutputBoundary presenter){
+    public CompleteTaskUseCase(CompleteTaskOutputBoundary presenter){
         this.presenter = presenter;
     }
 

--- a/src/main/java/use_cases/complete_task/CompletedTaskModel.java
+++ b/src/main/java/use_cases/complete_task/CompletedTaskModel.java
@@ -1,4 +1,4 @@
-package complete_task;
+package use_cases.complete_task;
 
 /**
  * A model class for packaging the required info needed by the completeTaskPresenter.


### PR DESCRIPTION
I completed the Add Task Use Case package with adherence to clean architecture.

The AddTaskController requires the UI to ask the user to choose a name and description for the new task as well as passing in the id of the parent class that the task is going to be added under (I have not yet implemented the case where there is no parent task) as well as the id of the curriculum that the new task is being added to.
The AddTaskPresenter displays a message confirming to the user that the task has been successfully added with the user's desired name and description, to the correct parent task and curriculum.

I will implement tests on the next PR, but wanted the UI people to have these classes to interact with.

Refactoring:
I also moved my complete_task and add_task packages to the use_case package
I also changed my class names to follow the proper convention.