### PR TITLE
Implemented outgoing use case classes for CreateCurriculum

### DIFF
--- a/src/main/java/use_cases/create_curriculum/CreateCurriculumPresenter.java
+++ b/src/main/java/use_cases/create_curriculum/CreateCurriculumPresenter.java
@@ -1,5 +1,7 @@
 package use_cases.create_curriculum;
 
+import java.util.List;
+
 /**
  * A presenter for providing output data to the view via an interface.
  * Created: 11/27/2022
@@ -9,14 +11,11 @@ package use_cases.create_curriculum;
  */
 public class CreateCurriculumPresenter implements CreateCurriculumOutputBoundary {
 
-    // private final DashboardUiInterface dashboard;
+    private final List<DashboardUiInterface> dashboardObservers;
 
-    /*
-    public CreateCurriculumPresenter(DashboardUiInterface dashboard) {
-        this.dashboard = dashboard;
+    public CreateCurriculumPresenter(List<DashboardUiInterface> dashboardObservers) {
+        this.dashboardObservers = dashboardObservers;
     }
-    TODO: Connect this presenter to the dashboard
-     */
 
     /**
      * Prepares the created curriculum for presentation
@@ -27,7 +26,6 @@ public class CreateCurriculumPresenter implements CreateCurriculumOutputBoundary
     public void displayCurriculum(CurriculumModel curriculumModel) {
         String successfullyCreatedCurriculumMsg = String.format("The %s curriculum (i.d. %d) was successfully created",
                 curriculumModel.getCurriculumName(), curriculumModel.getCurriculumID());
-        // this.dashboard.displayCurriculum(successfullyCreatedCurriculumMsg);
-        // TODO: Connect this to the dashboard
+        this.dashboardObservers.get(0).createdCurriculum(successfullyCreatedCurriculumMsg);
     }
 }

--- a/src/main/java/use_cases/create_curriculum/CreateCurriculumPresenter.java
+++ b/src/main/java/use_cases/create_curriculum/CreateCurriculumPresenter.java
@@ -9,6 +9,15 @@ package use_cases.create_curriculum;
  */
 public class CreateCurriculumPresenter implements CreateCurriculumOutputBoundary {
 
+    // private final DashboardUiInterface dashboard;
+
+    /*
+    public CreateCurriculumPresenter(DashboardUiInterface dashboard) {
+        this.dashboard = dashboard;
+    }
+    TODO: Connect this presenter to the dashboard
+     */
+
     /**
      * Prepares the created curriculum for presentation
      *
@@ -16,6 +25,9 @@ public class CreateCurriculumPresenter implements CreateCurriculumOutputBoundary
      */
     @Override
     public void displayCurriculum(CurriculumModel curriculumModel) {
-
+        String successfullyCreatedCurriculumMsg = String.format("The %s curriculum (i.d. %d) was successfully created",
+                curriculumModel.getCurriculumName(), curriculumModel.getCurriculumID());
+        // this.dashboard.displayCurriculum(successfullyCreatedCurriculumMsg);
+        // TODO: Connect this to the dashboard
     }
 }

--- a/src/main/java/use_cases/create_curriculum/DashboardUiInterface.java
+++ b/src/main/java/use_cases/create_curriculum/DashboardUiInterface.java
@@ -1,0 +1,12 @@
+package use_cases.create_curriculum;
+
+/**
+ * An interface for the CreateCurriculumPresenter to talk with the Dashboard
+ * Created: 12/1/2022
+ * Last updated: 12/1/2022
+ *
+ * @author MMachadoUofT
+ */
+public interface DashboardUiInterface {
+    void createdCurriculum(String message);
+}


### PR DESCRIPTION
This should complete the use case classes for creating a new curriculum. I've included an interface that the Dashboard will implement so that the presenter can properly notify it that it has created a curriculum in the entities layer, and so that the Dashboard can update itself accordingly. From here, all that's left for this use case is to connect it to the Dashboard, once implemented.